### PR TITLE
Setting an invalid gripper state no longer causes assertion error

### DIFF
--- a/neu_ro_arm/robot/robot_arm.py
+++ b/neu_ro_arm/robot/robot_arm.py
@@ -188,14 +188,14 @@ class RobotArm:
         Parameters
         ----------
         state : float
-            gripper state to move to; must be in range [0,1]
+            gripper state to move to; will be clipped to range [0,1]
 
         Returns
         -------
         bool
             True if desired gripper state was achieved
         '''
-        assert 0 <= state <= 1
+        state = np.clip(state, 0, 1)
         jpos = self.controller.gripper_state_to_jpos(state)
 
         self.controller.move_command(self.controller.gripper_joint_idxs, jpos)


### PR DESCRIPTION
It is possible that the user may try to set a gripper state outside [0,1].  In this case we should clip so that the robot continues operating instead of raising error.  In fact, it is possible to read a value outside [0,1] while in passive mode so if the user tries to play that back then we do not want an error to occur.